### PR TITLE
Update env_wrapper.py

### DIFF
--- a/env_wrapper.py
+++ b/env_wrapper.py
@@ -579,6 +579,25 @@ class EnvWrapper(object):
 
 
     def reset(self):
+        ### reset carla data provider, otherwise, the code running slower and slower
+        ### 重置CarlaDataProvider，否则，程序会越来越慢，因为很多东西并没有真正的删除，而是在后台占用tick的时间。
+        CarlaDataProvider.cleanup()
+        GameTime.restart()
+
+        CarlaDataProvider._training = self.training
+        CarlaDataProvider.set_client(self.client)
+        CarlaDataProvider.set_world(self.world)
+        CarlaDataProvider.set_traffic_manager_port(self.trafficManagerPort)
+        self.traffic_manager.set_synchronous_mode(True)
+        self.traffic_manager.set_random_device_seed(self.trafficManagerSeed)
+        if CarlaDataProvider.is_sync_mode():
+            # print("world snapshot frame: ", self.world.get_snapshot().frame)
+            self.world.tick()
+            # print("world snapshot frame: ", self.world.get_snapshot().frame)
+        else:
+            self.world.wait_for_tick()
+        ### end
+        
         self._step = 0
         self.last_event_timestamp = 0
         if self.sensor_interface is not None:


### PR DESCRIPTION
# 中文
解决tick越来越慢的问题

在你的代码中的env wrapper中，它的step方法，这句话：
  self.scenario_tree.tick_once()

比如使用simpletest.py，最开始七秒左右（我的1080ti显卡)，随着程序进行，会越来越慢，100个episode之内变到30秒。2000个episode之后，变到600秒。

经过调试发现，你的reset中忘记重置CarlaDataProvider。这个pr就是解决这个问题

# English
Solve the problem of tick running slow

in env_wrapper.py, the metho "step", this code
  self.scenario_tree.tick_once()

for example, in simpletest.py, from 7s / episode (in my 1080ti gpu), become 30s at 100 episode, and 600s / episode at 2000episode.

this PR solve this problem.

# simple_test log
我固定了route和scenario，查看运行时间，下面是输出日志：
```text
======================================== config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json route : 0, completion_ratio:17.44, terminate due to collision vehicles!. 
===========> in episode 0, sum reward for steer is 70.51, sum reward for throttle is 26.69 **_Episode 0 time: 10.094942569732666_** 
======================================== config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json WARNING: Actor model vehicle.harley-davidson.low_rider not available. Using instead vehicle.tesla.model3 route : 0, completion_ratio:16.65, terminate due to collision vehicles!. 
===========> in episode 1, sum reward for steer is 69.93, sum reward for throttle is 43.62 Episode 1 time: 9.919464588165283 
======================================== config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json route : 0, completion_ratio:15.86, terminate due to collision vehicles!. 
===========> in episode 2, sum reward for steer is 68.52, sum reward for throttle is 27.51 Episode 2 time: 10.003495216369629 
======================================== config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json route : 0, completion_ratio:16.65, terminate due to collision vehicles!. 
===========> in episode 3, sum reward for steer is 69.12, sum reward for throttle is 24.95 Episode 3 time: 10.307076454162598 config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json WARNING: Actor model vehicle.bh.crossbike not available. Using instead vehicle.tesla.model3 route : 0, completion_ratio:16.65, terminate due to collision vehicles!. 
===========> in episode 128, sum reward for steer is 69.12, sum reward for throttle is 25.02 E**_pisode 128 time: 32.020148038864136_** 
======================================== config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json route : 0, completion_ratio:17.44, terminate due to collision vehicles!. 
===========> in episode 129, sum reward for steer is 71.28, sum reward for throttle is 28.05 Episode 129 time: 33.81623983383179
 ======================================== config file: main/cadre/nocrash_scenarios/follow_lane_nocrash_scenarios/Town01/route00.json WARNING: Actor model vehicle.yamaha.yzf not available. Using instead vehicle.tesla.model3 route : 0, completion_ratio:16.65, terminate due to collision vehicles!. 
===========> in episode 130, sum reward for steer is 69.93, sum reward for throttle is 25.72 Episode 130 time: 33.088427782058716
```

